### PR TITLE
Adds editor script to manually normalize Rigidbodies

### DIFF
--- a/addons/rigidbody_auto_scaler/NormalizeRigidbodyScale.gd
+++ b/addons/rigidbody_auto_scaler/NormalizeRigidbodyScale.gd
@@ -1,0 +1,21 @@
+@tool 
+extends EditorScript
+
+# Forces all selected objects to be PhysicsBodies
+const STRICT = true
+
+var scaler = RigidbodyAutoScaler.new()
+
+func _run():
+	var selections = EditorInterface.get_selection().get_selected_nodes()
+	# ensure all selected nodes are rigidbodies before scaling is applied if in strict mode
+	if STRICT:
+		for node in selections:
+			assert(node is PhysicsBody2D or node is PhysicsBody3D, "Not all selected nodes are PhysicsBodies")
+	
+	# apply scale to children
+	for node in selections: 
+		if node is PhysicsBody2D:
+			scaler.scale_2d(node)
+		elif node is PhysicsBody3D:
+			scaler.scale_3d(node)

--- a/addons/rigidbody_auto_scaler/NormalizeRigidbodyScale.gd
+++ b/addons/rigidbody_auto_scaler/NormalizeRigidbodyScale.gd
@@ -16,6 +16,6 @@ func _run():
 	# apply scale to children
 	for node in selections: 
 		if node is PhysicsBody2D:
-			scaler.scale_2d(node)
+			scaler._scale_2d(node)
 		elif node is PhysicsBody3D:
-			scaler.scale_3d(node)
+			scaler._scale_3d(node)

--- a/addons/rigidbody_auto_scaler/RigidBodyAutoScaler.gd
+++ b/addons/rigidbody_auto_scaler/RigidBodyAutoScaler.gd
@@ -10,13 +10,13 @@ func _exit_tree() -> void:
 
 
 func _perform(node: Node):
-	if node is RigidBody2D:
+	if node is RigidBody2D or node is StaticBody2D:
 		_scale_2d(node)
-	elif node is RigidBody3D:
+	elif node is RigidBody3D or node is StaticBody3D:
 		_scale_3d(node)
 
 
-func _scale_2d(body: RigidBody2D):
+func _scale_2d(body: PhysicsBody2D):
 	# If the node has a scale of 1, there's nothing for us to do.
 	if body.global_scale.x == 1: return
 
@@ -30,7 +30,7 @@ func _scale_2d(body: RigidBody2D):
 	body.global_scale = Vector2.ONE
 
 
-func _scale_3d(body: RigidBody3D):
+func _scale_3d(body: PhysicsBody3D):
 	# First, we'll set this node to use "top level" mode. This basically
 	# disconnects it from its parents transform3d (which a rigidbody3d would
 	# do either way, because it's simulated in the physics world). It has the


### PR DESCRIPTION
This allows script allows you to trigger the rescaling at editor time by selecting a Rigidbody and running the editor script. This has the benefit of getting rid of the scaled RigidBody warning in the editor.