### PR TITLE
Removes 'coming soon' from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Minimum Godot version: 4.0
 
 ### Installing
 
-- Download it via the Godot Asset Library (coming soon)
+- Download it via the Godot Asset Library
 - Download [this repository's ZIP archive](https://github.com/hmans/Godot-RigidBody-Auto-Scaler/archive/refs/heads/main.zip), unpack it into your Godot project, and enable the plugin in your Project Settings
 
 ### How does it work?


### PR DESCRIPTION
Since the plugin is now available from the Godot asset browser, this is no longer accurate.